### PR TITLE
Only parse json if it's defined in oauth startup test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ jspm_packages
 
 # local run configuration
 .vscode
+.idea

--- a/README.md
+++ b/README.md
@@ -65,6 +65,26 @@ docker run --name testbouncer -it -p 8383:8083 --link mongodb:mongodb -e OAUTH_C
 
 See the ORCID documentation [on accessing the public API](https://members.orcid.org/api/accessing-public-api) and [signing-in with ORCID iD](https://members.orcid.org/api/integrate/orcid-sign-in). As a redirect URI you need to set the path `/api/v1/auth/login`, relative to your base URL. We highly recommend using `https`. The client ID & secret then need to be provided as environment variables or directly saved to the `config/config.js` file.
 
+When using the [o2r-guestlister](https://github.com/o2r-project/o2r-guestlister) offline OAuth2 implementation, the client ID and secret have to be identical to the values the o2r-guestlister is using.
+As long as these values match, they can be chosen freely.
+
+To match the default guestlister configuration the bouncer has to be configured to access the correct OAuth server:
+
+* `OAUTH_URL_AUTHORIZATION=http://.../oauth/authorize` 
+* `OAUTH_URL_TOKEN=http://.../oauth/token` 
+* `OAUTH_URL_CALLBACK=http://.../api/v1/auth/login` Bouncer 
+
+Keep in mind that `OAUTH_URL_TOKEN` is evoked by the bouncer, which means it has to be configured in respect to the bouncer's environment. 
+
+`OAUTH_URL_AUTHORIZATION` and `OAUTH_URL_CALLBACK` are evoked by the client.
+
+### Sessions
+
+The [express-session](https://github.com/expressjs/session) middleware is used to manage logged in users.
+After logging in via `/api/v1/auth/login`, a session cookie containing encoded information to identify the user is stored in the database. 
+
+The same cookie is sent to the client and allows continuous access to the o2r platform.
+
 ## Slack bot
 
 Documentation of Slack API: https://api.slack.com/bot-users, especially [interactive messages](https://api.slack.com/interactive-messages).

--- a/README.md
+++ b/README.md
@@ -74,9 +74,11 @@ To match the default guestlister configuration the bouncer has to be configured 
 * `OAUTH_URL_TOKEN=http://.../oauth/token`
 * `OAUTH_URL_CALLBACK=http://.../api/v1/auth/login`
 
-Keep in mind that `OAUTH_URL_TOKEN` is evoked by the bouncer, which means it has to be configured in respect to the bouncer's environment. 
+Keep in mind that `OAUTH_URL_TOKEN` is called by the bouncer, which means it has to be configured in respect to the bouncer's environment.
+This is especially relevant when bouncer is running inside a container.
+While `localhost` might work for development outside containers, the URL must use the proper host name in configurations based on docker-compose.
 
-`OAUTH_URL_AUTHORIZATION` and `OAUTH_URL_CALLBACK` are evoked by the client.
+`OAUTH_URL_AUTHORIZATION` and `OAUTH_URL_CALLBACK` are called by the client.
 
 ### Sessions
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ As long as these values match, they can be chosen freely.
 
 To match the default guestlister configuration the bouncer has to be configured to access the correct OAuth server:
 
-* `OAUTH_URL_AUTHORIZATION=http://.../oauth/authorize` 
-* `OAUTH_URL_TOKEN=http://.../oauth/token` 
-* `OAUTH_URL_CALLBACK=http://.../api/v1/auth/login` Bouncer 
+* `OAUTH_URL_AUTHORIZATION=http://.../oauth/authorize`
+* `OAUTH_URL_TOKEN=http://.../oauth/token`
+* `OAUTH_URL_CALLBACK=http://.../api/v1/auth/login`
 
 Keep in mind that `OAUTH_URL_TOKEN` is evoked by the bouncer, which means it has to be configured in respect to the bouncer's environment. 
 

--- a/index.js
+++ b/index.js
@@ -83,43 +83,6 @@ if (typeof config.oauth.default.clientID == 'undefined' |
   process.exit(4);
 }
 
-// make sure required settings are valid
-if (config.oauth.startup.test) {
-  debug('Requesting %s credentials at %s to test OAuth configuration', config.oauth.default.testScope, config.oauth.default.tokenURL);
-  var options = {
-    uri: config.oauth.default.tokenURL,
-    method: 'POST',
-    headers: {
-      'Content-type': 'application/json'
-    },
-    form: {
-      client_id: config.oauth.default.clientID,
-      client_secret: config.oauth.default.clientSecret,
-      grant_type: "client_credentials",
-      scope: config.oauth.default.testScope
-    }
-  };
-
-  request(options, (err, response, body) => {
-    let resp;
-    if (body) { resp = JSON.parse(body); }
-    if (err || resp.error) {
-      debug('Error validating OAuth credentials (fail start? %s): err: %s response: %s'.red,
-        config.oauth.startup.failOnError.toString().toUpperCase(), JSON.stringify(err), JSON.stringify(resp));
-      if (config.oauth.startup.failOnError) {
-        console.error('Shutting down because OAuth startup test failed: %s'.red, JSON.stringify(resp));
-        process.exit(5);
-      }
-    } else {
-      if (resp.access_token && resp.scope === config.oauth.default.testScope) {
-        debug('Retrieved access token and requested scope, all OK: %o'.green, resp);
-      } else {
-        debug('Did not receive expected response, continuing still... %o'.yellow, resp);
-      }
-    }
-  });
-}
-
 // configure oauth2 strategy for orcid use
 const oauth2 = new OAuth2Strat(
   config.oauth.default,
@@ -168,6 +131,43 @@ passport.deserializeUser((id, cb) => {
 
 function initApp(callback) {
   debug('Initialize application');
+
+  // make sure required settings are valid
+  if (config.oauth.startup.test) {
+      debug('Requesting %s credentials at %s to test OAuth configuration', config.oauth.default.testScope, config.oauth.default.tokenURL);
+      var options = {
+          uri: config.oauth.default.tokenURL,
+          method: 'POST',
+          headers: {
+              'Content-type': 'application/json'
+          },
+          form: {
+              client_id: config.oauth.default.clientID,
+              client_secret: config.oauth.default.clientSecret,
+              grant_type: "client_credentials",
+              scope: config.oauth.default.testScope
+          }
+      };
+
+      request(options, (err, response, body) => {
+          let resp;
+          if (body) { resp = JSON.parse(body); }
+          if (err || resp.error) {
+              debug('Error validating OAuth credentials (fail start? %s): err: %s response: %s'.red,
+                  config.oauth.startup.failOnError.toString().toUpperCase(), JSON.stringify(err), JSON.stringify(resp));
+              if (config.oauth.startup.failOnError) {
+                  console.error('Shutting down because OAuth startup test failed: %s'.red, JSON.stringify(resp));
+                  process.exit(5);
+              }
+          } else {
+              if (resp.access_token && resp.scope === config.oauth.default.testScope) {
+                  debug('Retrieved access token and requested scope, all OK: %o'.green, resp);
+              } else {
+                  debug('Did not receive expected response, continuing still... %o'.yellow, resp);
+              }
+          }
+      });
+  }
 
   try {
     const mongoStore = new MongoStore({

--- a/index.js
+++ b/index.js
@@ -74,13 +74,57 @@ userViewSingle = require('./lib/user').viewSingle;
 userPatchLevel = require('./lib/user').patchLevel;
 
 // make sure required settings without defaults are availabe
-if (typeof config.oauth.default.clientID == 'undefined' |
-  typeof config.oauth.default.clientSecret == 'undefined') {
+if (typeof config.oauth.default.clientID === 'undefined' ||
+  typeof config.oauth.default.clientSecret === 'undefined') {
   console.error('Cannot start because: %s %s'.red,
-    (typeof config.oauth.default.clientID == 'undefined') ? 'clientID is missing;' : '',
-    (typeof config.oauth.default.clientSecret == 'undefined') ? 'clientSecret is missing;' : ''
+    (typeof config.oauth.default.clientID === 'undefined') ? 'clientID is missing;' : '',
+    (typeof config.oauth.default.clientSecret === 'undefined') ? 'clientSecret is missing;' : ''
   );
   process.exit(4);
+}
+
+// make sure required settings are valid
+if (config.oauth.startup.test) {
+    debug('Requesting %s credentials at %s to test OAuth configuration', config.oauth.default.testScope, config.oauth.default.tokenURL);
+    var options = {
+        uri: config.oauth.default.tokenURL,
+        method: 'POST',
+        headers: {
+            'Content-type': 'application/json'
+        },
+        form: {
+            client_id: config.oauth.default.clientID,
+            client_secret: config.oauth.default.clientSecret,
+            grant_type: "client_credentials",
+            scope: config.oauth.default.testScope
+        }
+    };
+
+    request(options, (err, response, body) => {
+        let resp = {};
+        if (body) {
+            try {
+                resp = JSON.parse(body);
+            } catch (err) {
+                debug('Error parsing startup test response: %s', err);
+            }
+        }
+
+        if (err || resp.error) {
+            debug('Error validating OAuth credentials (fail start? %s): err: %s response: %s'.red,
+                config.oauth.startup.failOnError.toString().toUpperCase(), JSON.stringify(err), JSON.stringify(resp));
+            if (config.oauth.startup.failOnError) {
+                console.error('Shutting down because OAuth startup test failed: %s'.red, JSON.stringify(resp));
+                process.exit(5);
+            }
+        } else {
+            if (resp.access_token && resp.scope === config.oauth.default.testScope) {
+                debug('Retrieved access token and requested scope, all OK: %o'.green, resp);
+            } else {
+                debug('Did not receive expected response, continuing still... %o'.yellow, resp);
+            }
+        }
+    });
 }
 
 // configure oauth2 strategy for orcid use
@@ -131,44 +175,6 @@ passport.deserializeUser((id, cb) => {
 
 function initApp(callback) {
   debug('Initialize application');
-
-  // make sure required settings are valid
-  if (config.oauth.startup.test) {
-      debug('Requesting %s credentials at %s to test OAuth configuration', config.oauth.default.testScope, config.oauth.default.tokenURL);
-      var options = {
-          uri: config.oauth.default.tokenURL,
-          method: 'POST',
-          headers: {
-              'Content-type': 'application/json'
-          },
-          form: {
-              client_id: config.oauth.default.clientID,
-              client_secret: config.oauth.default.clientSecret,
-              grant_type: "client_credentials",
-              scope: config.oauth.default.testScope
-          }
-      };
-
-      request(options, (err, response, body) => {
-          let resp;
-          if (body) { resp = JSON.parse(body); }
-          if (err || resp.error) {
-              debug('Error validating OAuth credentials (fail start? %s): err: %s response: %s'.red,
-                  config.oauth.startup.failOnError.toString().toUpperCase(), JSON.stringify(err), JSON.stringify(resp));
-              if (config.oauth.startup.failOnError) {
-                  console.error('Shutting down because OAuth startup test failed: %s'.red, JSON.stringify(resp));
-                  process.exit(5);
-              }
-          } else {
-              if (resp.access_token && resp.scope === config.oauth.default.testScope) {
-                  debug('Retrieved access token and requested scope, all OK: %o'.green, resp);
-              } else {
-                  debug('Did not receive expected response, continuing still... %o'.yellow, resp);
-              }
-          }
-      });
-  }
-
   try {
     const mongoStore = new MongoStore({
       uri: config.mongo.location + config.mongo.database,

--- a/index.js
+++ b/index.js
@@ -98,10 +98,11 @@ if (config.oauth.startup.test) {
       grant_type: "client_credentials",
       scope: config.oauth.default.testScope
     }
-  }
+  };
 
   request(options, (err, response, body) => {
-    let resp = JSON.parse(body);
+    let resp;
+    if (body) { resp = JSON.parse(body); }
     if (err || resp.error) {
       debug('Error validating OAuth credentials (fail start? %s): err: %s response: %s'.red,
         config.oauth.startup.failOnError.toString().toUpperCase(), JSON.stringify(err), JSON.stringify(resp));

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -26,7 +26,7 @@ const util = require('util');
 
 // start listening to the slack team associated to the token
 exports.start = function (error, done) {
-  if (config.slack.verification_token == null || config.slack.bot_token == null) {
+  if (!config.slack.verification_token || !config.slack.bot_token || config.slack.verification_token.length === 0 || config.slack.bot_token.length === 0) {
     debug('Slack bot token and/or verification token not properly configured: bot token = %s | verification_token = %s', config.slack.bot_token, config.slack.verification_token);
     error(new Error('Required Slack environment variables not available.'));
     return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bouncer",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Node.js implementation of authentication features of the [o2r web api](http://o2r.info/o2r-web-api).",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes the following problem:

When the bouncer does the startup test and the `token` URL is not reachable the bouncer fails without logging anything:

```
undefined:1
bouncer_1         | undefined
bouncer_1         | ^
bouncer_1         | 
bouncer_1         | SyntaxError: Unexpected token u in JSON at position 0
bouncer_1         |     at Object.parse (native)
bouncer_1         |     at Request.request [as _callback] (/bouncer/index.js:102:21)
bouncer_1         |     at self.callback (/bouncer/node_modules/request/request.js:186:22)
bouncer_1         |     at emitOne (events.js:96:13)
bouncer_1         |     at Request.emit (events.js:188:7)
bouncer_1         |     at Request.onRequestError (/bouncer/node_modules/request/request.js:878:8)
bouncer_1         |     at emitOne (events.js:96:13)
bouncer_1         |     at ClientRequest.emit (events.js:188:7)
bouncer_1         |     at Socket.socketErrorListener (_http_client.js:310:9)
bouncer_1         |     at emitOne (events.js:96:13)
bouncer_1         |     at Socket.emit (events.js:188:7)
bouncer_1         |     at emitErrorNT (net.js:1281:8)
bouncer_1         |     at _combinedTickCallback (internal/process/next_tick.js:80:11)
bouncer_1         |     at process._tickCallback (internal/process/next_tick.js:104:9)

```